### PR TITLE
Standardize Pi.Alert name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 
 
 
-# Pi-hole + Unbound + PiAlert Setup
+# Pi-hole + Unbound + Pi.Alert Setup
 
 ![Pi-hole + Unbound Setup](https://github.com/TimInTech/Pi-hole-Unbound-PiAlert-Setup/blob/main/eea62b352f4d0301.png)
 
-This repository provides a detailed guide on setting up **Pi-hole with Unbound** as a local DNS resolver and **PiAlert** for network monitoring.
+This repository provides a detailed guide on setting up **Pi-hole with Unbound** as a local DNS resolver and **Pi.Alert** for network monitoring.
+
+**Note:** This guide consistently uses the official "Pi.Alert" spelling.
 
 ## 📌 Comprehensive Pi-hole 6 Configuration
 If you're looking for an **in-depth guide** with additional optimizations, check out my full **Pi-hole v6.0 - Comprehensive Guide**:


### PR DESCRIPTION
## Summary
- update README heading and intro
- use "Pi.Alert" consistently
- mention official spelling near the intro

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a65346b94833391087e3b797b3fdf